### PR TITLE
Add a missing sha256

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,7 @@ gazelle_dependencies()
 # Make buildifier available. See https://github.com/bazelbuild/buildtools/tree/master/buildifier#setup-and-usage-via-bazel
 http_archive(
     name = "com_google_protobuf",
+    sha256 = "91b4c2f4c028aa2bb7f6ade9ba9c5f04ce3f4cc52a38779e05bc0a967cdb0eb1",
     strip_prefix = "protobuf-master",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
 )


### PR DESCRIPTION
This fixes a build warning about reproducibility for com_google_protobuf.