### PR TITLE
Use circleci to run all bazel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+# Use a package of configuration called an orb.
+orbs:
+  # Declare a dependency on the welcome-orb
+  welcome: circleci/welcome-orb@0.4.1
+# Orchestrate or schedule a set of jobs
+workflows:
+  # Name the workflow "welcome"
+  welcome:
+    # Run the welcome/run job in its own container
+    jobs:
+      - welcome/run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,18 @@
 version: 2.1
 jobs:
   test:
-    docker:
-      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.14.7
+          #docker:
+    # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
+    #- image: circleci/golang:1.14.7
+      #- image: circleci/python:3.8.5
+    machine:
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       # Install bazelisk. See https://github.com/bazelbuild/bazelisk#requirements
       - run: go get github.com/bazelbuild/bazelisk
+      # Install python3 for haskell
+      #- run: sudo apt-get install python3
       - run: bazelisk test //...
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,17 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-# Use a package of configuration called an orb.
-orbs:
-  # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.4.1
-# Orchestrate or schedule a set of jobs
+jobs:
+  test:
+    docker:
+      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
+      - image: circleci/golang:1.14.7
+    steps:
+      - checkout
+      # Install bazelisk. See https://github.com/bazelbuild/bazelisk#requirements
+      - run: go get github.com/bazelbuild/bazelisk
+      - run: bazelisk test //...
+
 workflows:
-  # Name the workflow "welcome"
-  welcome:
-    # Run the welcome/run job in its own container
+  test-workflow:
     jobs:
-      - welcome/run
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # Install bazelisk. See https://github.com/bazelbuild/bazelisk#requirements
       - run: go get github.com/bazelbuild/bazelisk
       # Install python3 for haskell
-      #- run: sudo apt-get install python3
+      ##- run: sudo apt-get install python3
       - run: bazelisk test //...
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,14 @@
 version: 2.1
 jobs:
   test:
-          #docker:
-    # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
-    #- image: circleci/golang:1.14.7
-      #- image: circleci/python:3.8.5
+    # Use a machine executor because it most easily supports multiple languages
     machine:
+      # See https://circleci.com/docs/2.0/configuration-reference/#machine for the list of images
       image: ubuntu-1604:202004-01
     steps:
       - checkout
       # Install bazelisk. See https://github.com/bazelbuild/bazelisk#requirements
       - run: go get github.com/bazelbuild/bazelisk
-      # Install python3 for haskell
-      ##- run: sudo apt-get install python3
       - run: bazelisk test //...
 
 workflows:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,7 @@ gazelle_dependencies()
 # Make buildifier available. See https://github.com/bazelbuild/buildtools/tree/master/buildifier#setup-and-usage-via-bazel
 http_archive(
     name = "com_google_protobuf",
+    sha256 = "91b4c2f4c028aa2bb7f6ade9ba9c5f04ce3f4cc52a38779e05bc0a967cdb0eb1"
     strip_prefix = "protobuf-master",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,7 +35,7 @@ gazelle_dependencies()
 # Make buildifier available. See https://github.com/bazelbuild/buildtools/tree/master/buildifier#setup-and-usage-via-bazel
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "91b4c2f4c028aa2bb7f6ade9ba9c5f04ce3f4cc52a38779e05bc0a967cdb0eb1"
+    sha256 = "91b4c2f4c028aa2bb7f6ade9ba9c5f04ce3f4cc52a38779e05bc0a967cdb0eb1",
     strip_prefix = "protobuf-master",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
 )


### PR DESCRIPTION
I want to try out and move to circleci to learn it as well as travis (will eventually remove travis). This is partially because the algular project moved from travis to circleci and uses bazel. I don't know why they moved away but I'll give it a try.