### PR TITLE
Fix the circleci build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,9 +35,9 @@ gazelle_dependencies()
 # Make buildifier available. See https://github.com/bazelbuild/buildtools/tree/master/buildifier#setup-and-usage-via-bazel
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "91b4c2f4c028aa2bb7f6ade9ba9c5f04ce3f4cc52a38779e05bc0a967cdb0eb1",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    sha256 = "d8dfa7697e1b7c8f4d36a6838f476052f0ecf7cb49dbb13391623c05b7e1aa7b",
+    strip_prefix = "protobuf-3.12.4",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.12.4/protobuf-all-3.12.4.zip"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
This is done by specifying the latest protobuf release and the hash for
it.