### PR TITLE
Remove buildifier from WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,8 +36,6 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
-protobuf_deps()
-
 http_archive(
     name = "gtest",
     sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,23 +36,7 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
-# Make buildifier available. See https://github.com/bazelbuild/buildtools/tree/master/buildifier#setup-and-usage-via-bazel
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "ff0fa865b5973dfa3206856342ac16184a9d7f3280ab870a07da2026863fa7cb",
-    strip_prefix = "protobuf-3.13.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-all-3.13.0.zip"],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
 protobuf_deps()
-
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
-)
 
 http_archive(
     name = "gtest",


### PR DESCRIPTION
It is used and installed via yarn instead.