### PR TITLE
Use a map instead of an object for nthPrime

### DIFF
--- a/projecteuler/p0007/10001st_prime.ts
+++ b/projecteuler/p0007/10001st_prime.ts
@@ -1,31 +1,31 @@
 // This does an unbounded sieve
 export const nthPrime = function (n: number): number {
-  // Need a map from number to a list of numbers
-  const multiples: {[multiple: number]: number[]} = {};
-  // Create a helper since Javascript doesn't have great multimap or
-  // defaultdict support.
-  const addMultiple = function (multiple: number, prime: number): void {
-    if (multiple in multiples) {
-      multiples[multiple].push(prime);
-    } else {
-      multiples[multiple] = [prime];
+  // A map from composite numbers to the prime factors that resulted in them being known-composite
+  const composites = new Map<number, number[]>();
+  const addComposite = function (composite: number, prime: number): void {
+    let primes = composites.get(composite);
+    if (!primes) {
+      primes = [];
+      composites.set(composite, primes);
     }
+    primes.push(prime);
   };
   let latestPrime = 2;
   let numPrimes = 1;
   for (let i = 3; numPrimes < n; i += 2) {
-    if (i in multiples) {
-      for (const p of multiples[i]) {
+    const primes = composites.get(i);
+    if (primes) {
+      for (const p of primes) {
         // We are skipping evens so ignore i + 2p next
-        addMultiple(i + 2 * p, p);
+        addComposite(i + 2 * p, p);
       }
-      delete multiples[i];
+      composites.delete(i);
     } else {
       numPrimes += 1;
       latestPrime = i;
       // The next multiple to check should not be divisible by
       // any smaller prime so check i*i next
-      addMultiple(i * i, i);
+      addComposite(i * i, i);
     }
   }
   return latestPrime;

--- a/projecteuler/p0007/10001st_prime_test.ts
+++ b/projecteuler/p0007/10001st_prime_test.ts
@@ -5,5 +5,6 @@ describe('nthPrime', () => {
     expect(nthPrime(1)).toBe(2);
     expect(nthPrime(6)).toBe(13);
     expect(nthPrime(10001)).toBe(104743);
+    expect(nthPrime(1000000)).toBe(15485863);
   });
 });


### PR DESCRIPTION
According to the "Objects vs Maps" section of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map maps are better optimized to adding and removing elements. This results in the 1-millionth prime being found in ~6 seconds instead of ~9.