### PR TITLE
Improve problem 1.3's probability convergence

### DIFF
--- a/probability-and-computing/chapter1/1.3.ts
+++ b/probability-and-computing/chapter1/1.3.ts
@@ -8,8 +8,7 @@
 
 export type Deck = number[];
 
-const shuffle = function (cards: Deck, numCards: number) {
-	assert(numCards <= 52);
+export const shuffle = function (cards: Deck, numCards: number) {
   for (let i = 0; i < numCards; i++) {
     const k = Math.floor(Math.random() * (cards.length - i)) + i;
     [cards[i], cards[k]] = [cards[k], cards[i]];
@@ -17,48 +16,65 @@ const shuffle = function (cards: Deck, numCards: number) {
   return cards;
 };
 
-export const sampler = (function () {
+export const deck = (function () {
   const cards = new Array(52);
   for (let i = 0; i < cards.length; i++) {
     cards[i] = i;
   }
-  return function () {
-    return shuffle(cards);
-  };
+  return cards;
 })();
+
+export type Predicate = {
+  predicate: (deck: Deck) => boolean;
+  // Knowing the number of cards used by the predicate allows for more efficient
+  // sampling by only selecting a small number of cards, rather than shuffling the whole deck.
+  numCardsUsed: number;
+};
 
 const rank = function (card: number) {
   return card % 13;
 };
 
-export const predicateA = function (cards: Deck) {
-  return rank(cards[0]) === 12 || rank(cards[1]) === 12;
+export const predicateA = {
+  predicate: function (cards: Deck) {
+    return rank(cards[0]) === 12 || rank(cards[1]) === 12;
+  },
+  numCardsUsed: 2,
 };
 
-export const predicateB = function (cards: Deck) {
-  for (let i = 0; i < 5; i++) {
-    if (rank(cards[i]) === 12) {
-      return true;
+export const predicateB = {
+  predicate: function (cards: Deck) {
+    for (let i = 0; i < 5; i++) {
+      if (rank(cards[i]) === 12) {
+        return true;
+      }
     }
-  }
-  return false;
+    return false;
+  },
+  numCardsUsed: 5,
 };
 
-export const predicateC = function (cards: Deck) {
-  return rank(cards[0]) === rank(cards[1]);
+export const predicateC = {
+  predicate: function (cards: Deck) {
+    return rank(cards[0]) === rank(cards[1]);
+  },
+  numCardsUsed: 2,
 };
 
-export const predicateD = function (cards: Deck) {
-  const rankCounts: {[key: number]: number} = {};
-  for (let i = 0; i < 5; i++) {
-    const cardRank = rank(cards[i]);
-    rankCounts[cardRank] = rankCounts[cardRank] + 1 || 1;
-    if (Object.keys(rankCounts).length > 2) {
-      return false;
+export const predicateD = {
+  predicate: function (cards: Deck) {
+    const rankCounts: {[key: number]: number} = {};
+    for (let i = 0; i < 5; i++) {
+      const cardRank = rank(cards[i]);
+      rankCounts[cardRank] = rankCounts[cardRank] + 1 || 1;
+      if (Object.keys(rankCounts).length > 2) {
+        return false;
+      }
+      if (rankCounts[cardRank] === 4) {
+        return false;
+      }
     }
-    if (rankCounts[cardRank] === 4) {
-      return false;
-    }
-  }
-  return true;
+    return true;
+  },
+  numCardsUsed: 5,
 };

--- a/probability-and-computing/chapter1/1.3.ts
+++ b/probability-and-computing/chapter1/1.3.ts
@@ -8,8 +8,9 @@
 
 export type Deck = number[];
 
-const shuffle = function (cards: Deck) {
-  for (let i = 0; i < cards.length - 1; i++) {
+const shuffle = function (cards: Deck, numCards: number) {
+	assert(numCards <= 52);
+  for (let i = 0; i < numCards; i++) {
     const k = Math.floor(Math.random() * (cards.length - i)) + i;
     [cards[i], cards[k]] = [cards[k], cards[i]];
   }

--- a/probability-and-computing/chapter1/1.3_test.ts
+++ b/probability-and-computing/chapter1/1.3_test.ts
@@ -1,14 +1,13 @@
 import {
   Deck,
-  sampler,
+  Predicate,
+  deck,
   predicateA,
   predicateB,
   predicateC,
   predicateD,
+  shuffle,
 } from './1.3';
-
-type Sampler = () => Deck;
-type Predicate = (deck: Deck) => boolean;
 
 describe('1.3', () => {
   const pointsAfterDecimal = function (p: number) {
@@ -27,17 +26,16 @@ describe('1.3', () => {
     });
   });
   const expectProbabilityConvergesTo = function (
-    sampler: Sampler,
-    filter: Predicate,
+    predicate: Predicate,
     p: number
   ) {
     let positiveSamples = 0;
     let numCloseConsecutiveSamples = 0;
     const precision = pointsAfterDecimal(p) + 2; // Be within 2 decimal points
-    const maxSamples = 100000000;
+    const maxSamples = 10_000_000;
     for (let numSamples = 1; numSamples <= maxSamples; numSamples++) {
-      const sample = sampler();
-      if (filter(sample)) {
+      shuffle(deck, predicate.numCardsUsed);
+      if (predicate.predicate(deck)) {
         positiveSamples += 1;
       }
       const observedProbability = positiveSamples / numSamples;
@@ -47,41 +45,32 @@ describe('1.3', () => {
       } else {
         numCloseConsecutiveSamples = 0;
       }
-      // We must have sampled at least 100 decks and been within precision
-      // range for a proportion of the number of samples so far. These
-      // numbers are tuned such that the test should run quickly but also
-      // be fairly confident the predicate is converging.
-      if (numSamples > 100 && numCloseConsecutiveSamples >= numSamples / 10) {
+      if (numCloseConsecutiveSamples >= 100) {
         expect(observedProbability).toBeCloseTo(p, precision);
         return;
       }
     }
     expect(positiveSamples / maxSamples).toBeCloseTo(p, precision);
   };
-  describe('sampler', () => {
-    it('generates a permutation of 0..51', () => {
-      const cards = sampler();
-      expect(cards.length).toBe(52);
-      const seenCards: {[key: number]: boolean} = {};
-      for (let i = 0; i < cards.length; i++) {
-        seenCards[i] = true;
+  describe('deck', () => {
+    it('is a permutation of 0..51', () => {
+      expect(deck.length).toBe(52);
+      const seenCards = new Set();
+      for (let i = 0; i < deck.length; i++) {
+        seenCards.add(i);
       }
-      expect(Object.keys(seenCards).length).toBe(52);
-    });
-  });
-  describe('predicateD', () => {
-    it('should return true for full houses', () => {
-      expect(predicateD([0, 13, 26, 1, 14])).toBe(true);
-      expect(predicateD([0, 13, 39, 1, 14])).toBe(true);
-      expect(predicateD([2, 13, 39, 1, 14])).toBe(false);
+      expect(seenCards.size).toBe(52);
     });
   });
   describe('expectProbabilityConvergesTo', () => {
     it('should converge to 1 / 2', () => {
-      const firstCardIsEven = function (cards: Deck) {
-        return cards[0] % 2 === 0;
+      const firstCardIsEven = {
+        predicate: function (cards: Deck) {
+          return cards[0] % 2 === 0;
+        },
+        numCardsUsed: 1,
       };
-      expectProbabilityConvergesTo(sampler, firstCardIsEven, 1 / 2);
+      expectProbabilityConvergesTo(firstCardIsEven, 1 / 2);
     });
   });
   it('answers a', () => {
@@ -93,11 +82,7 @@ describe('1.3', () => {
     // 1 - (((48 permute 2) * 50!) / 52!)
     // 1 - 48!50! / 46!52!
     // 1 - (48 * 47) / (52 * 51)
-    expectProbabilityConvergesTo(
-      sampler,
-      predicateA,
-      1 - (48 * 47) / (52 * 51)
-    );
+    expectProbabilityConvergesTo(predicateA, 1 - (48 * 47) / (52 * 51));
   });
   it('answers b', () => {
     // (b) The first five cards include at least one ace.
@@ -106,7 +91,6 @@ describe('1.3', () => {
     // 1 - 48!47! / 43!52!
     // 1 - (47 * 46 * 45 * 44) / (52 * 51 * 50 * 49)
     expectProbabilityConvergesTo(
-      sampler,
       predicateB,
       1 - (47 * 46 * 45 * 44) / (52 * 51 * 50 * 49)
     );
@@ -117,18 +101,24 @@ describe('1.3', () => {
     // ((13 choose 1) * (4 permute 2) * 50! / 52!)
     // (13 * 4!/2! * 50!) / 52!
     // (13 * 12) / (52 * 51)
-    expectProbabilityConvergesTo(sampler, predicateC, (13 * 12) / (52 * 51));
+    expectProbabilityConvergesTo(predicateC, (13 * 12) / (52 * 51));
   });
-  it('answers d', () => {
-    // (d) The first five cards form a full house.
-    // Choose two ranks. Choose three of one, two of the other.
-    // Permute the 5 cards. Then permute the rest.
-    // ((13 choose 2) * (4 choose 3) * (4 choose 2) * 5! * 47!) / 52!
-    // 13*12/2 * 4 * 12 * 120 / 52*51*50*49*48
-    expectProbabilityConvergesTo(
-      sampler,
-      predicateD,
-      (13 * 6 * 4 * 12 * 120) / (52 * 51 * 50 * 49 * 48)
-    );
+  describe('predicateD', () => {
+    it('should return true for full houses', () => {
+      expect(predicateD.predicate([0, 13, 26, 1, 14])).toBe(true);
+      expect(predicateD.predicate([0, 13, 39, 1, 14])).toBe(true);
+      expect(predicateD.predicate([2, 13, 39, 1, 14])).toBe(false);
+    });
+    it('answers d', () => {
+      // (d) The first five cards form a full house.
+      // Choose two ranks. Choose three of one, two of the other.
+      // Permute the 5 cards. Then permute the rest.
+      // ((13 choose 2) * (4 choose 3) * (4 choose 2) * 5! * 47!) / 52!
+      // 13*12/2 * 4 * 12 * 120 / 52*51*50*49*48
+      expectProbabilityConvergesTo(
+        predicateD,
+        (13 * 6 * 4 * 12 * 120) / (52 * 51 * 50 * 49 * 48)
+      );
+    });
   });
 });

--- a/probability-and-computing/chapter1/1.3_test.ts
+++ b/probability-and-computing/chapter1/1.3_test.ts
@@ -11,6 +11,21 @@ type Sampler = () => Deck;
 type Predicate = (deck: Deck) => boolean;
 
 describe('1.3', () => {
+  const pointsAfterDecimal = function (p: number) {
+    let i = 0;
+    while (p < 1) {
+      p *= 10;
+      i++;
+    }
+    return i;
+  };
+  describe('pointsAfterDecimal', () => {
+    it('returns expected values', () => {
+      expect(pointsAfterDecimal(0.5)).toBe(1);
+      expect(pointsAfterDecimal(0.01)).toBe(2);
+      expect(pointsAfterDecimal(0.000001)).toBe(6);
+    });
+  });
   const expectProbabilityConvergesTo = function (
     sampler: Sampler,
     filter: Predicate,
@@ -18,8 +33,8 @@ describe('1.3', () => {
   ) {
     let positiveSamples = 0;
     let numCloseConsecutiveSamples = 0;
-    const precision = 2; // Be within 2 decimal points
-    const maxSamples = 10000000;
+    const precision = pointsAfterDecimal(p) + 2; // Be within 2 decimal points
+    const maxSamples = 100000000;
     for (let numSamples = 1; numSamples <= maxSamples; numSamples++) {
       const sample = sampler();
       if (filter(sample)) {

--- a/probability-and-computing/chapter1/1.3_test.ts
+++ b/probability-and-computing/chapter1/1.3_test.ts
@@ -31,7 +31,7 @@ describe('1.3', () => {
   ) {
     let positiveSamples = 0;
     let numCloseConsecutiveSamples = 0;
-    const precision = pointsAfterDecimal(p) + 2; // Be within 2 decimal points
+    const precision = pointsAfterDecimal(p) + 2; // Be within a few decimal points
     const maxSamples = 10_000_000;
     for (let numSamples = 1; numSamples <= maxSamples; numSamples++) {
       shuffle(deck, predicate.numCardsUsed);
@@ -45,7 +45,7 @@ describe('1.3', () => {
       } else {
         numCloseConsecutiveSamples = 0;
       }
-      if (numCloseConsecutiveSamples >= 100) {
+      if (numCloseConsecutiveSamples >= 10) {
         expect(observedProbability).toBeCloseTo(p, precision);
         return;
       }


### PR DESCRIPTION
The original approach would not ensure that we are within some precision of the specified probability. So if the probability of the predicate was 0.000001 we could stop when we get to 0.001 and think our answer is right. The way this works in this PR is that first the number of decimal places is calculated and then we iterate until our predicate seems to be within 2 decimal points of that for a few iterations.