### PR TITLE
Fix the fix_buildifier script

### DIFF
--- a/.circleci/fix_buildifier
+++ b/.circleci/fix_buildifier
@@ -3,5 +3,5 @@
 set -e # Exit on error
 
 find . -name "BUILD.bazel" -not -path "./node_modules/*" \
-  | yarn buildifier --lint=fix --mode=fix --warnings=all
+  | xargs yarn buildifier --lint=fix --mode=fix --warnings=all
 yarn buildifier --lint=fix --mode=fix --warnings=all WORKSPACE


### PR DESCRIPTION
It was piping to `yarn`, not to `xargs` as it should have been.