### PR TITLE
Add all update types to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,10 +15,14 @@
             ],
             "groupName": "everything",
             "matchUpdateTypes": [
+                "bump",
+                "digest"
+                "lockFileMaintenance",
+                "major",
                 "minor",
                 "patch",
                 "pin",
-                "digest"
+                "rollback"
             ]
         }
     ],

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
             "groupName": "everything",
             "matchUpdateTypes": [
                 "bump",
-                "digest"
+                "digest",
                 "lockFileMaintenance",
                 "major",
                 "minor",


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#matchupdatetypes for the list. Seems like lock file maintenance was already happening, just trying this out for curiosity.