### PR TITLE
Add functions for computing gaps and applied gaps

### DIFF
--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -105,3 +105,9 @@ def reduced_residue_system_primorial_gaps(i):
         gaps.append(rrs[k] - rrs[k - 1])
     gaps.append(2)
     return gaps
+
+
+def reduced_residue_system_primorial_applied_gaps(i):
+    rrs = sorted(reduced_residue_system_primorial(i))
+    gaps = reduced_residue_system_primorial_gaps(i)
+    return [rrs[k] + gaps[k] for k in range(len(rrs))]

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -8,6 +8,7 @@ from reduced_residue_system import (
     filter_twin_primes, filter_twos, reduced_residue_system_primorial,
     prime_and_composite_between_prime_and_primorial,
     reduced_residue_system_primorial_twos,
+    reduced_residue_system_primorial_applied_gaps,
     reduced_residue_system_primorial_gaps,
     twin_primes_between_prime_and_primorial)
 from sympy import primorial
@@ -199,6 +200,20 @@ class Test(unittest.TestCase):
             2, 4, 2, 4, 8, 6, 4, 6, 2, 4, 6, 2, 6, 6, 4, 2, 4, 6, 2, 6, 4, 2, 4,
             2, 10, 2
         ], reduced_residue_system_primorial_gaps(4))
+
+    def test_reduced_residue_system_primorial_applied_gaps(self):
+        self.assertEqual([3], reduced_residue_system_primorial_applied_gaps(1))
+        self.assertEqual([5, 7],
+                         reduced_residue_system_primorial_applied_gaps(2))
+        self.assertEqual([7, 11, 13, 17, 19, 23, 29, 31],
+                         reduced_residue_system_primorial_applied_gaps(3))
+        print(reduced_residue_system_primorial_applied_gaps(4))
+        self.assertEqual([
+            11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73,
+            79, 83, 89, 97, 101, 103, 107, 109, 113, 121, 127, 131, 137, 139,
+            143, 149, 151, 157, 163, 167, 169, 173, 179, 181, 187, 191, 193,
+            197, 199, 209, 211
+        ], reduced_residue_system_primorial_applied_gaps(4))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The gaps and applied gaps came up when counting twin primes in the RRS primorial sets. For RRS(1) = {1} using the naive approach of checking if 1 and 1 + 2 are twin primes results in it not counting {3, 5} as a twin prime. But all the other cases are fine. That's because for that first case the RRS set is not counting the desired quantity, which is the concept of applying the gaps to the RRS which gives {3} for the first case which does give (3, 5) as a twin prime. This is because primorial(1) < prime(1) -> 2 < 3 but for all greater numbers i > 1, primorial(i) > prime(i).

This just explains why when counting properties of 2s using just RRS's, a special case on 1 is needed: it's simpler often to work with RRSs because they are simpler to define but really what's desired is working with applied gaps to RRSs which are more complicated to define. 