### PR TITLE
Add a function for calculating the min prime descendant

### DIFF
--- a/fun/sieve/BUILD.bazel
+++ b/fun/sieve/BUILD.bazel
@@ -36,3 +36,12 @@ py_binary(
         "reduced_residue_system",
     ],
 )
+
+py_binary(
+    name = "min_prime_descendants",
+    srcs = ["min_prime_descendants.py"],
+    deps = [
+        "reduced_residue_system",
+        requirement("sympy"),
+    ],
+)

--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -1,0 +1,20 @@
+from itertools import count
+from reduced_residue_system import min_prime_descendant, reduced_residue_system_primorial
+from sympy import isprime
+
+
+def main():
+    # A map from residues to the i at which they were first seen
+    seen_residues = {}
+    for i in count(start=2):
+        for residue in sorted(reduced_residue_system_primorial(i)):
+            if residue in seen_residues or isprime(residue):
+                continue
+            seen_residues[residue] = i
+            descendant, j = min_prime_descendant(residue, i)
+            if j - i > 1 or len(seen_residues) % 1000 == 0:
+                print(residue, i, descendant, j)
+
+
+if __name__ == '__main__':
+    main()

--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -1,6 +1,6 @@
 # See https://en.wikipedia.org/wiki/Reduced_residue_system
 
-from collections import namedtuple
+from collections import deque, namedtuple
 from functools import cache
 from math import gcd
 from sympy.ntheory.modular import crt
@@ -108,6 +108,7 @@ def composite_and_composite_between_prime_and_primorial(i):
 
 
 # The elements that the residue r in rss(i) contributes to rss(i + 1)
+# Children are yielded in sorted order.
 def children(residue, i):
     primorial_i = primorial(i)
     next_prime = prime(i + 1)
@@ -142,6 +143,24 @@ def min_extension(residue, i):
     if residue == 1 or isprime(residue):
         return (residue, i)
     return min_extension(min_child(residue, i), i + 1)
+
+
+# Look at each descendant in a breadth first manner until a prime is found.
+def min_prime_descendant(residue, i):
+    if isprime(residue):
+        return (residue, i)
+    queue = deque()
+    queue.appendleft((residue, i))
+    while True:
+        residue, i = queue.pop()
+        for child in children(residue, i):
+            if isprime(child):
+                return (child, i + 1)
+            queue.appendleft((child, i + 1))
+
+    # Idea is to go one level deep, check all children for primality.
+    # Then go two levels deep starting with the first child and check all of its
+    # children for primality and continue for the other children.
 
 
 def reduced_residue_system_primorial_gaps(i):

--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -158,10 +158,6 @@ def min_prime_descendant(residue, i):
                 return (child, i + 1)
             queue.appendleft((child, i + 1))
 
-    # Idea is to go one level deep, check all children for primality.
-    # Then go two levels deep starting with the first child and check all of its
-    # children for primality and continue for the other children.
-
 
 def reduced_residue_system_primorial_gaps(i):
     rrs = sorted(reduced_residue_system_primorial(i))

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -6,8 +6,8 @@ from reduced_residue_system import (
     composite_and_composite_between_prime_and_primorial,
     composite_and_prime_between_prime_and_primorial, filter_twin_primes,
     filter_twos, full_prime_residues, min_child, min_extension,
-    prime_and_composite_between_prime_and_primorial, prime_residues,
-    prime_residues_inverse, reduced_residue_system_primorial,
+    min_prime_descendant, prime_and_composite_between_prime_and_primorial,
+    prime_residues, prime_residues_inverse, reduced_residue_system_primorial,
     reduced_residue_system_primorial_two_classification,
     reduced_residue_system_primorial_twos,
     reduced_residue_system_primorial_applied_gaps,
@@ -197,6 +197,9 @@ class Test(unittest.TestCase):
         self.assertEqual(11, min_child(5, 2))
         self.assertEqual(37, min_child(7, 3))
         self.assertEqual(11, min_child(11, 3))
+        self.assertEqual(331, min_child(121, 4))
+        self.assertEqual(169, min_child(169, 4))
+        self.assertEqual(2479, min_child(169, 5))
 
     def test_min_extension(self):
         # Primes are already considered fully extended
@@ -224,6 +227,25 @@ class Test(unittest.TestCase):
         self.assertEqual((353, 5), min_extension(143, 4))
         self.assertEqual((397, 5), min_extension(187, 4))
         self.assertEqual((419, 5), min_extension(209, 4))
+
+    def test_min_prime_descendant(self):
+        self.assertEqual((331, 5), min_prime_descendant(121, 4))
+        self.assertEqual((353, 5), min_prime_descendant(143, 4))
+        self.assertEqual((379, 5), min_prime_descendant(169, 4))
+        self.assertEqual((397, 5), min_prime_descendant(187, 4))
+        self.assertEqual((419, 5), min_prime_descendant(209, 4))
+
+        # These require going more than one level deep and are so cool.
+        self.assertEqual((19525829, 9), min_prime_descendant(126449, 7))
+        self.assertEqual((9913361, 9), min_prime_descendant(213671, 7))
+        self.assertEqual((10120951, 9), min_prime_descendant(421261, 7))
+        self.assertEqual((892971133, 10), min_prime_descendant(599653, 8))
+        self.assertEqual((1116141781, 10), min_prime_descendant(677431, 8))
+        self.assertEqual((1339256201, 10), min_prime_descendant(698981, 8))
+        self.assertEqual((223877011, 10), min_prime_descendant(784141, 8))
+        self.assertEqual((456749701, 10), min_prime_descendant(864271, 8))
+        self.assertEqual((447287131, 10), min_prime_descendant(1101391, 8))
+        self.assertEqual((224434261, 10), min_prime_descendant(1341391, 8))
 
     def test_children_residues(self):
         self.assertEqual((1,), prime_residues(1, 1))


### PR DESCRIPTION
This is within the context of the RRS tree.

This is neat because given a prefix, this extends it to the smallest prime with that prefix. I have no idea if it'll always terminate.