### PR TITLE
Use less memory for the min_prime_descendants script

### DIFF
--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -1,16 +1,13 @@
 from itertools import count
-from reduced_residue_system import min_prime_descendant, reduced_residue_system_primorial
+from reduced_residue_system import min_prime_descendant, reduced_residue_system_primorial_new
 from sympy import isprime
 
 
 def main():
-    # A map from residues to the i at which they were first seen
-    seen_residues = {}
     for i in count(start=2):
-        for residue in reduced_residue_system_primorial(i):
-            if residue in seen_residues or isprime(residue):
+        for residue in reduced_residue_system_primorial_new(i):
+            if isprime(residue):
                 continue
-            seen_residues[residue] = i
             descendant, j = min_prime_descendant(residue, i)
             if j - i > 1:
                 print(residue, i, descendant, j)

--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -39,6 +39,20 @@ def reduced_residue_system_primorial(i):
             yield child
 
 
+def reduced_residue_system_primorial_new(i):
+    """
+    Like reduced_residue_system_primorial(i) but only only yields elements not
+    in reduced_residue_system_primorial(i - 1).
+    """
+    if i == 1:
+        yield 1
+        return
+    for residue in reduced_residue_system_primorial(i - 1):
+        for child in children(residue, i - 1):
+            if child != residue:
+                yield child
+
+
 def filter_twos(rrs):
     # A "two" is a residue that corresponds to a 2 in the corresponding dRRS.
     # That means that r and r + 2 is in the RRS.

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -9,6 +9,7 @@ from reduced_residue_system import (
     min_prime_descendant, prime_and_composite_between_prime_and_primorial,
     prime_residues, prime_residues_inverse, primoradic,
     primorial_multiplicative_inverse, reduced_residue_system_primorial,
+    reduced_residue_system_primorial_new,
     reduced_residue_system_primorial_two_classification,
     reduced_residue_system_primorial_twos,
     reduced_residue_system_primorial_applied_gaps,
@@ -52,6 +53,17 @@ class Test(unittest.TestCase):
             139, 143, 149, 151, 157, 163, 167, 169, 173, 179, 181, 187, 191,
             193, 197, 199, 209
         ], sorted(reduced_residue_system_primorial(4)))
+
+    def test_reduced_residue_system_primorial_new(self):
+        self.assertEqual([1], sorted(reduced_residue_system_primorial_new(1)))
+        self.assertEqual([5], sorted(reduced_residue_system_primorial_new(2)))
+        self.assertEqual([7, 11, 13, 17, 19, 23, 29],
+                         sorted(reduced_residue_system_primorial_new(3)))
+        self.assertEqual([
+            31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101,
+            103, 107, 109, 113, 121, 127, 131, 137, 139, 143, 149, 151, 157,
+            163, 167, 169, 173, 179, 181, 187, 191, 193, 197, 199, 209
+        ], sorted(reduced_residue_system_primorial_new(4)))
 
     def test_reduced_residue_system_primorial_sizes(self):
         sizes = {


### PR DESCRIPTION
The script had a 'seen' map, which is unnecessary since it is reasonably easy to add a way to generate just the new or unique elements of rrs(i) not in rrs(i - 1). The name `reduced_residue_system_primorial_new` could be confusing but seems like a reasonable choice.