### PR TITLE
Add a helper function that iterates through all primorial RRSs

### DIFF
--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -3,6 +3,7 @@
 from collections import deque, namedtuple
 from functools import cache
 from math import gcd
+from itertools import count
 from sympy.ntheory.modular import crt
 from sympy import isprime, nextprime, primepi, primerange
 
@@ -51,6 +52,18 @@ def reduced_residue_system_primorial_new(i):
         for child in children(residue, i - 1):
             if child != residue:
                 yield child
+
+
+def all_reduced_residue_system_primorial():
+    """
+    Iterates through all unique elements of all primorial reduced residue systems.
+    Each residue is returned only for the first system it is a member of.
+
+    Yields tuples (r, i) where r is the residue and i is the system it is first seen in.
+    """
+    for i in count(start=1):
+        for residue in reduced_residue_system_primorial_new(i):
+            yield (residue, i)
 
 
 def filter_twos(rrs):

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -69,7 +69,7 @@ class Test(unittest.TestCase):
 
     def test_all_reduced_residue_system_primorial(self):
         first_several = sorted(
-            islice(all_reduced_residue_system_primorial(), 11))
+            islice(all_reduced_residue_system_primorial(), 50))
         self.assertEqual([(1, 1), (5, 2), (7, 3), (11, 3), (13, 3), (17, 3),
                           (19, 3), (23, 3), (29, 3), (31, 4), (37, 4), (41, 4),
                           (43, 4), (47, 4), (53, 4), (59, 4), (61, 4), (67, 4),

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -68,10 +68,18 @@ class Test(unittest.TestCase):
         ], sorted(reduced_residue_system_primorial_new(4)))
 
     def test_all_reduced_residue_system_primorial(self):
-        first_several = islice(all_reduced_residue_system_primorial(), 11)
-        self.assertEqual([(1, 1), (5, 2)(7, 3), (11, 3), (17, 3), (19, 3),
-                          (23, 3), (29, 3), (31, 4), (37, 4), (41, 4)],
-                         first_several)
+        first_several = sorted(
+            islice(all_reduced_residue_system_primorial(), 11))
+        self.assertEqual([(1, 1), (5, 2), (7, 3), (11, 3), (13, 3), (17, 3),
+                          (19, 3), (23, 3), (29, 3), (31, 4), (37, 4), (41, 4),
+                          (43, 4), (47, 4), (53, 4), (59, 4), (61, 4), (67, 4),
+                          (71, 4), (73, 4), (79, 4), (83, 4), (89, 4), (97, 4),
+                          (101, 4), (103, 4), (107, 4), (109, 4), (113, 4),
+                          (121, 4), (127, 4), (131, 4), (137, 4), (139, 4),
+                          (143, 4), (149, 4), (151, 4), (157, 4), (163, 4),
+                          (167, 4), (169, 4), (173, 4), (179, 4), (181, 4),
+                          (187, 4), (191, 4), (193, 4), (197, 4), (199, 4),
+                          (209, 4)], first_several)
 
     def test_reduced_residue_system_primorial_sizes(self):
         sizes = {

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -68,10 +68,11 @@ class Test(unittest.TestCase):
         ], sorted(reduced_residue_system_primorial_new(4)))
 
     def test_all_reduced_residue_system_primorial(self):
-        self.assertEqual([(1, 1), (5, 2)],
+        self.assertEqual([(1, 1), (5, 2)(7, 3), (11, 3), (17, 3), (19, 3),
+                          (23, 3), (29, 3), (31, 4), (37, 4), (41, 4)],
                          sorted(
                              islice(all_reduced_residue_system_primorial(),
-                                    10),))
+                                    11),))
 
     def test_reduced_residue_system_primorial_sizes(self):
         sizes = {

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -68,11 +68,10 @@ class Test(unittest.TestCase):
         ], sorted(reduced_residue_system_primorial_new(4)))
 
     def test_all_reduced_residue_system_primorial(self):
+        first_several = islice(all_reduced_residue_system_primorial(), 11)
         self.assertEqual([(1, 1), (5, 2)(7, 3), (11, 3), (17, 3), (19, 3),
                           (23, 3), (29, 3), (31, 4), (37, 4), (41, 4)],
-                         sorted(
-                             islice(all_reduced_residue_system_primorial(),
-                                    11),))
+                         first_several)
 
     def test_reduced_residue_system_primorial_sizes(self):
         sizes = {

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -1,8 +1,10 @@
 import unittest
 
 from math import gcd
+from itertools import islice
 from reduced_residue_system import (
-    _reduced_residue_system_primorial_brute_force, children,
+    _reduced_residue_system_primorial_brute_force,
+    all_reduced_residue_system_primorial, children,
     composite_and_composite_between_prime_and_primorial,
     composite_and_prime_between_prime_and_primorial, filter_twin_primes,
     filter_twos, full_prime_residues, min_child, min_extension,
@@ -64,6 +66,12 @@ class Test(unittest.TestCase):
             103, 107, 109, 113, 121, 127, 131, 137, 139, 143, 149, 151, 157,
             163, 167, 169, 173, 179, 181, 187, 191, 193, 197, 199, 209
         ], sorted(reduced_residue_system_primorial_new(4)))
+
+    def test_all_reduced_residue_system_primorial(self):
+        self.assertEqual([(1, 1), (5, 2)],
+                         sorted(
+                             islice(all_reduced_residue_system_primorial(),
+                                    10),))
 
     def test_reduced_residue_system_primorial_sizes(self):
         sizes = {


### PR DESCRIPTION
This will be helpful in parallelizing min_prime_descendants.py.