### PR TITLE
Add the ability to start at a particular rrs to min_prime_descendants

### DIFF
--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -4,7 +4,9 @@ import sys
 from concurrent.futures import ProcessPoolExecutor
 from itertools import islice, repeat
 from multiprocessing import Manager
-from reduced_residue_system import all_reduced_residue_system_primorial, min_prime_descendant, reduced_residue_system_primorial_new
+from reduced_residue_system import (all_reduced_residue_system_primorial,
+                                    min_prime_descendant,
+                                    reduced_residue_system_primorial_new)
 
 
 def report_intersting_descendants(chunk, result_queue, completion_queue):

--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -1,10 +1,10 @@
+import queue
+import sys
+
 from concurrent.futures import ProcessPoolExecutor
 from itertools import islice, repeat
 from multiprocessing import Manager
 from reduced_residue_system import all_reduced_residue_system_primorial, min_prime_descendant, reduced_residue_system_primorial_new
-
-import queue
-import sys
 
 
 def report_intersting_descendants(chunk, result_queue, completion_queue):

--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -1,4 +1,3 @@
-import queue
 import sys
 
 from concurrent.futures import ProcessPoolExecutor

--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -33,7 +33,7 @@ def main():
         while True:
             # Drain the completion queue to get the number of outstanding processes.
             while not completion_queue.empty():
-                completion_queue.get_nowait()
+                completion_queue.get()
                 num_outstanding -= 1
 
             # Wait until a process completes if the number of outstanding


### PR DESCRIPTION
The search through i=11 didn't find any prime descendants needing to go 3 levels deep but was interrupted for some reason. This allows for checking larger rrs sets more easily.