### PR TITLE
Add a simple way of calculating the min prime descendant

### DIFF
--- a/fun/sieve/min_prime_descendants.py
+++ b/fun/sieve/min_prime_descendants.py
@@ -4,8 +4,9 @@ from concurrent.futures import ProcessPoolExecutor
 from itertools import count, islice, repeat
 from multiprocessing import Manager
 from reduced_residue_system import (all_reduced_residue_system_primorial,
-                                    interesting_composites,
+                                    ancestors, interesting_composites,
                                     min_prime_descendant, primoradic,
+                                    random_rrsp,
                                     reduced_residue_system_primorial_new)
 
 
@@ -71,9 +72,24 @@ def interesting():
                 return
 
 
+def random():
+    while True:
+        residue = random_rrsp(80)
+        print('Trying out', residue)
+        for i, ancestor in enumerate(ancestors(residue), start=1):
+            descendant, j = min_prime_descendant(ancestor, i)
+            if j - i > 1:
+                print(ancestor, i, descendant, j, primoradic(ancestor),
+                      primoradic(descendant))
+            if j - i > 2:
+                return
+
+
 def main():
     if sys.argv[1] == 'interesting':
         interesting()
+    elif sys.argv[1] == 'random':
+        random()
     else:
         exhaustive()
 

--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -190,26 +190,25 @@ def min_prime_descendant(residue, i):
         return (residue, i)
     queue = deque()
     queue.appendleft((residue, i))
-    min_child = None
+    min_prime_child = None
     min_i = None
-    while not min_child:
+    while not min_prime_child:
         residue, i = queue.pop()
         for child in children(residue, i):
             if isprime(child):
-                min_child = child
+                min_prime_child = child
                 min_i = i + 1
                 break
-            else:
-                queue.appendleft((child, i + 1))
+            queue.appendleft((child, i + 1))
 
     # Consume the rest of the queue to get the minimum
     while queue:
         residue, i = queue.pop()
         for child in children(residue, i):
-            if child < min_child and isprime(child):
-                min_child = child
+            if child < min_prime_child and isprime(child):
+                min_prime_child = child
 
-    return min_child, min_i
+    return min_prime_child, min_i
 
 
 def min_prime_descendant_simple(residue, i):
@@ -218,6 +217,10 @@ def min_prime_descendant_simple(residue, i):
         num = residue + k * primorial_i
         if isprime(num):
             return num
+    # By https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions
+    # a prime will always be found so this "return None" is unreachable but it
+    # makes pytlint happy.
+    return None
 
 
 def primoradic(num):

--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -5,7 +5,7 @@ from functools import cache
 from math import gcd
 from itertools import count
 from sympy.ntheory.modular import crt
-from sympy import isprime, nextprime, primepi, primerange
+from sympy import isprime, nextprime, prevprime, primepi, primerange
 
 import sympy
 
@@ -282,3 +282,57 @@ def prime_residues_inverse(residues):
 
 def full_prime_residues(num):
     return prime_residues(num, primepi(num))
+
+
+def min_composite(i):
+    # There are no composites in rrsp(1..3)
+    if i < 4:
+        return None
+    return prime(i + 1) * prime(i + 1)
+
+
+def max_power_composite(i):
+    if i < 4:
+        return None
+    num = prime(i + 1) * prime(i + 1)
+    while num * prime(i + 1) < primorial(i):
+        num *= prime(i + 1)
+    return num
+
+
+def most_unique_factors_composite(i):
+    if i < 4:
+        return None
+    next_prime = prime(i + 1)
+    num = next_prime
+    while num < primorial(i):
+        next_prime = nextprime(next_prime)
+        num *= next_prime
+    return num // next_prime
+
+
+def max_square_composite(i):
+    if i < 4:
+        return None
+    prime_index = i + 1
+    while prime(prime_index)**2 < primorial(i):
+        prime_index += 1
+    return prime(prime_index - 1)**2
+
+
+def max_consecutive_primes_composite(i):
+    if i < 4:
+        return None
+    prime_index = i + 1
+    while prime(prime_index) * prime(prime_index + 1) < primorial(i):
+        prime_index += 1
+    return prime(prime_index - 1) * prime(prime_index)
+
+
+def longest_prime_gap_composite(i):
+    if i < 4:
+        return None
+    quotient = primorial(i) // prime(i + 1)
+    if isprime(quotient):
+        return quotient * prime(i + 1)
+    return prevprime(quotient) * prime(i + 1)

--- a/fun/sieve/reduced_residue_system.py
+++ b/fun/sieve/reduced_residue_system.py
@@ -190,12 +190,34 @@ def min_prime_descendant(residue, i):
         return (residue, i)
     queue = deque()
     queue.appendleft((residue, i))
-    while True:
+    min_child = None
+    min_i = None
+    while not min_child:
         residue, i = queue.pop()
         for child in children(residue, i):
             if isprime(child):
-                return (child, i + 1)
-            queue.appendleft((child, i + 1))
+                min_child = child
+                min_i = i + 1
+                break
+            else:
+                queue.appendleft((child, i + 1))
+
+    # Consume the rest of the queue to get the minimum
+    while queue:
+        residue, i = queue.pop()
+        for child in children(residue, i):
+            if child < min_child and isprime(child):
+                min_child = child
+
+    return min_child, min_i
+
+
+def min_prime_descendant_simple(residue, i):
+    primorial_i = primorial(i)
+    for k in count():
+        num = residue + k * primorial_i
+        if isprime(num):
+            return num
 
 
 def primoradic(num):

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -306,8 +306,7 @@ class Test(unittest.TestCase):
             for residue in reduced_residue_system_primorial(i):
                 descendant, _ = min_prime_descendant(residue, i)
                 self.assertEqual(descendant,
-                                 min_prime_descendant_simple(residue, i),
-                                 msg='residue == %s, i == %s' % (residue, i))
+                                 min_prime_descendant_simple(residue, i))
 
         # These require going more than one level deep and are so cool.
         self.assertEqual(10336649, min_prime_descendant_simple(126449, 7))

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -11,7 +11,7 @@ from reduced_residue_system import (
     longest_prime_gap_composite, max_power_composite,
     max_consecutive_primes_composite, max_square_composite, min_child,
     min_composite, min_extension, min_prime_descendant,
-    most_unique_factors_composite, parent,
+    min_prime_descendant_simple, most_unique_factors_composite, parent,
     prime_and_composite_between_prime_and_primorial, prime_residues,
     prime_residues_inverse, primoradic, primoradic_to_int,
     primorial_multiplicative_inverse, random_rrsp,
@@ -288,16 +288,38 @@ class Test(unittest.TestCase):
         self.assertEqual((419, 5), min_prime_descendant(209, 4))
 
         # These require going more than one level deep and are so cool.
-        self.assertEqual((19525829, 9), min_prime_descendant(126449, 7))
+        self.assertEqual((10336649, 9), min_prime_descendant(126449, 7))
         self.assertEqual((9913361, 9), min_prime_descendant(213671, 7))
         self.assertEqual((10120951, 9), min_prime_descendant(421261, 7))
-        self.assertEqual((892971133, 10), min_prime_descendant(599653, 8))
-        self.assertEqual((1116141781, 10), min_prime_descendant(677431, 8))
-        self.assertEqual((1339256201, 10), min_prime_descendant(698981, 8))
+        self.assertEqual((243091903, 10), min_prime_descendant(599653, 8))
+        self.assertEqual((301367821, 10), min_prime_descendant(677431, 8))
+        self.assertEqual((233491541, 10), min_prime_descendant(698981, 8))
         self.assertEqual((223877011, 10), min_prime_descendant(784141, 8))
-        self.assertEqual((456749701, 10), min_prime_descendant(864271, 8))
-        self.assertEqual((447287131, 10), min_prime_descendant(1101391, 8))
+        self.assertEqual((243356521, 10), min_prime_descendant(864271, 8))
+        self.assertEqual((272692711, 10), min_prime_descendant(1101391, 8))
         self.assertEqual((224434261, 10), min_prime_descendant(1341391, 8))
+
+    def test_min_prime_descendant_simple(self):
+        self.assertEqual(3, min_prime_descendant_simple(1, 1))
+
+        for i in range(2, 6):
+            for residue in reduced_residue_system_primorial(i):
+                descendant, _ = min_prime_descendant(residue, i)
+                self.assertEqual(descendant,
+                                 min_prime_descendant_simple(residue, i),
+                                 msg='residue == %s, i == %s' % (residue, i))
+
+        # These require going more than one level deep and are so cool.
+        self.assertEqual(10336649, min_prime_descendant_simple(126449, 7))
+        self.assertEqual(9913361, min_prime_descendant_simple(213671, 7))
+        self.assertEqual(10120951, min_prime_descendant_simple(421261, 7))
+        self.assertEqual(243091903, min_prime_descendant_simple(599653, 8))
+        self.assertEqual(301367821, min_prime_descendant_simple(677431, 8))
+        self.assertEqual(233491541, min_prime_descendant_simple(698981, 8))
+        self.assertEqual(223877011, min_prime_descendant_simple(784141, 8))
+        self.assertEqual(243356521, min_prime_descendant_simple(864271, 8))
+        self.assertEqual(272692711, min_prime_descendant_simple(1101391, 8))
+        self.assertEqual(224434261, min_prime_descendant_simple(1341391, 8))
 
     def test_children_residues(self):
         self.assertEqual((1,), prime_residues(1, 1))

--- a/fun/sieve/reduced_residue_system_test.py
+++ b/fun/sieve/reduced_residue_system_test.py
@@ -7,8 +7,10 @@ from reduced_residue_system import (
     all_reduced_residue_system_primorial, children,
     composite_and_composite_between_prime_and_primorial,
     composite_and_prime_between_prime_and_primorial, filter_twin_primes,
-    filter_twos, full_prime_residues, min_child, min_extension,
-    min_prime_descendant, parent,
+    filter_twos, full_prime_residues, longest_prime_gap_composite,
+    max_power_composite, max_consecutive_primes_composite, max_square_composite,
+    min_child, min_composite, min_extension, min_prime_descendant,
+    most_unique_factors_composite, parent,
     prime_and_composite_between_prime_and_primorial, prime_residues,
     prime_residues_inverse, primoradic, primoradic_to_int,
     primorial_multiplicative_inverse, reduced_residue_system_primorial,
@@ -473,6 +475,48 @@ class Test(unittest.TestCase):
         self.assertEqual(3, primorial_multiplicative_inverse(5))
         self.assertEqual(15, primorial_multiplicative_inverse(6))
         self.assertEqual(18, primorial_multiplicative_inverse(7))
+
+    def test_min_composite(self):
+        self.assertEqual(None, min_composite(3))
+        self.assertEqual(11**2, min_composite(4))
+        self.assertEqual(13**2, min_composite(5))
+        self.assertEqual(17**2, min_composite(6))
+
+    def test_max_power_composite(self):
+        self.assertEqual(None, max_power_composite(3))
+        self.assertEqual(11**2, max_power_composite(4))
+        self.assertEqual(13**3, max_power_composite(5))
+        self.assertEqual(17**3, max_power_composite(6))
+        self.assertEqual(19**4, max_power_composite(7))
+
+    def test_most_unique_factors_composite(self):
+        self.assertEqual(None, most_unique_factors_composite(3))
+        self.assertEqual(11 * 13, most_unique_factors_composite(4))
+        self.assertEqual(13 * 17, most_unique_factors_composite(5))
+        self.assertEqual(17 * 19 * 23, most_unique_factors_composite(6))
+        self.assertEqual(19 * 23 * 29 * 31, most_unique_factors_composite(7))
+        self.assertEqual(23 * 29 * 31 * 37, most_unique_factors_composite(8))
+
+    def test_max_square_composite(self):
+        self.assertEqual(None, max_square_composite(3))
+        self.assertEqual(13**2, max_square_composite(4))
+        self.assertEqual(47**2, max_square_composite(5))
+        self.assertEqual(173**2, max_square_composite(6))
+        self.assertEqual(709**2, max_square_composite(7))
+
+    def test_max_consecutive_primes_composite(self):
+        self.assertEqual(None, max_consecutive_primes_composite(3))
+        self.assertEqual(11 * 13, max_consecutive_primes_composite(4))
+        self.assertEqual(43 * 47, max_consecutive_primes_composite(5))
+        self.assertEqual(167 * 173, max_consecutive_primes_composite(6))
+        self.assertEqual(709 * 719, max_consecutive_primes_composite(7))
+
+    def test_longest_prime_gap_composite(self):
+        self.assertEqual(None, longest_prime_gap_composite(3))
+        self.assertEqual(11 * 19, longest_prime_gap_composite(4))
+        self.assertEqual(13 * 173, longest_prime_gap_composite(5))
+        self.assertEqual(17 * 1759, longest_prime_gap_composite(6))
+        self.assertEqual(19 * 26863, longest_prime_gap_composite(7))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This goes over some composites unnecessarily but that is fine. This along with https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions makes it easier to see that there must be a minimum prime descendant. It also makes it more clear that the original `min_prime_descendants` was really just returning the first prime descendant.